### PR TITLE
Do not send optional values as nil to gecko

### DIFF
--- a/lib/gecko/graph/line.rb
+++ b/lib/gecko/graph/line.rb
@@ -40,11 +40,11 @@ module Gecko
       end
 
       def x_axis
-        { :labels => labels, :type => type }
+        compact({ :labels => labels, :type => type })
       end
 
       def y_axis
-        { :format => format, :unit => unit }
+        compact({ :format => format, :unit => unit })
       end
 
       def data_payload
@@ -56,11 +56,13 @@ module Gecko
       end
 
       def serie_payload(serie)
-        h = { :data => serie.data }
-        %w(name incomplete_from type).each do |k|
-          h.merge!(k.to_sym => serie.send(k)) if serie.send(k)
-        end
-        h
+        compact(serie.to_h)
+      end
+
+      private
+
+      def compact(hash)
+        hash.select { |_, value| !value.nil? }
       end
     end
   end

--- a/spec/gecko/line_spec.rb
+++ b/spec/gecko/line_spec.rb
@@ -12,8 +12,8 @@ describe Gecko::Widget::Line do
       expect(@widget.payload).to be_a_valid_payload(
         TEST_API_KEY,
         {
-          :x_axis => { :labels => nil, :type => nil },
-          :y_axis => { :format => nil, :unit => nil },
+          :x_axis => {},
+          :y_axis => {},
           :series => []
         }
       )
@@ -25,8 +25,8 @@ describe Gecko::Widget::Line do
       expect(@widget.payload).to be_a_valid_payload(
         TEST_API_KEY,
         {
-          :x_axis => { :labels => ['a', 'b', 'c'], :type => nil },
-          :y_axis => { :format => nil, :unit => nil },
+          :x_axis => { :labels => ['a', 'b', 'c'] },
+          :y_axis => {},
           :series => [{
             :data => [5, 6, 7]
           }]
@@ -43,8 +43,8 @@ describe Gecko::Widget::Line do
       expect(@widget.payload).to be_a_valid_payload(
         TEST_API_KEY,
         {
-          :x_axis => { :labels => ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"], :type => nil },
-          :y_axis => { :format => 'currency', :unit => nil },
+          :x_axis => { :labels => ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] },
+          :y_axis => { :format => 'currency' },
           :series => [
             {:data => [1.62529, 1.56991], :name => "GBP -> USD"},
             {:data => [1.23226, 1.15025], :name => "GBP -> EUR"}


### PR DESCRIPTION
When we send nil for optional values, it will override default values in Geckoboard
